### PR TITLE
CE-477 Couchbase Version 7.1.3 Support

### DIFF
--- a/plugin_config.yml
+++ b/plugin_config.yml
@@ -1,7 +1,7 @@
 id: 18f4ff11-b758-4bf2-9a37-719a22f5a4b8
 name: sc:couchbase
-externalVersion: "1.2.1.3"
-buildNumber: 1.2.1.3
+externalVersion: "1.2.2"
+buildNumber: 1.2.2
 language: PYTHON38
 hostTypes:
 - UNIX

--- a/schema.json
+++ b/schema.json
@@ -275,8 +275,7 @@
       "bucketSize",
       "couchbaseAdmin",
       "couchbaseAdminPassword",
-      "xdcrAdmin",
-      "xdcrAdminPassword"
+      "xdcrAdmin"
     ],
     "ordering" : [
       "dSourceType",

--- a/src/controller/couchbase_lib/_bucket.py
+++ b/src/controller/couchbase_lib/_bucket.py
@@ -214,7 +214,7 @@ class _BucketMixin(Resource, MixinInterface):
         while pending_docs != 0:
             logger.debug("Documents pending for replication: {}".format(pending_docs))
             helper_lib.sleepForSecond(30)
-            stdout, stderr, exit_code = utilities.execute_bash(self.connection, command, **kwargs)
+            stdout, stderr, exit_code = utilities.execute_expect(self.connection, command, **kwargs)
             content = json.loads(stdout)
             pending_docs = self._get_last_value_of_node_stats(list(content["nodeStats"].values())[0])
         else:

--- a/src/controller/couchbase_lib/_cb_backup.py
+++ b/src/controller/couchbase_lib/_cb_backup.py
@@ -63,7 +63,7 @@ class _CBBackupMixin(Resource, MixinInterface):
         # logger.debug("Backup restore: {}".format(cmd))
         # utilities.execute_bash(self.connection, cmd, **kwargs)
         map_data_list = []
-        if int(self.repository.version.split(".")[0]) == 7:
+        if int(self.repository.version.split(".")[0]) >= 7:
             for bucket_name in csv_bucket.split(","):
                 logger.debug(f"bucket_name: {bucket_name}")
                 stdout, _, _ = self.run_couchbase_command(

--- a/src/controller/couchbase_lib/_cb_backup.py
+++ b/src/controller/couchbase_lib/_cb_backup.py
@@ -6,6 +6,7 @@
 """This class contains methods for all cb backup manager.
 This is child class of Resource and parent class of CouchbaseOperation
 """
+import json
 #######################################################################################################################
 import logging
 from utils import utilities
@@ -61,14 +62,36 @@ class _CBBackupMixin(Resource, MixinInterface):
         #                                     **env)
         # logger.debug("Backup restore: {}".format(cmd))
         # utilities.execute_bash(self.connection, cmd, **kwargs)
-
+        map_data_list = []
+        if int(self.repository.version.split(".")[0]) == 7:
+            for bucket_name in csv_bucket.split(","):
+                logger.debug(f"bucket_name: {bucket_name}")
+                stdout, _, _ = self.run_couchbase_command(
+                    couchbase_command='get_scope_list_expect',
+                    base_path=helper_lib.get_base_directory_of_given_path(
+                        self.repository.cb_shell_path),
+                    bucket_name=bucket_name
+                )
+                json_scope_data = json.loads(stdout)
+                for s in json_scope_data["scopes"]:
+                    scope_name = s["name"]
+                    if scope_name == "_default":
+                        continue
+                    collection_list = s["collections"]
+                    for c in collection_list:
+                        collection_name = c["name"]
+                        if collection_name == "_default":
+                            continue
+                        map_data_list.append(f"{bucket_name}.{scope_name}.{collection_name}={bucket_name}.{scope_name}.{collection_name}")
 
         stdout, stderr, exit_code = self.run_couchbase_command(couchbase_command='cb_backup_full',
                                                             backup_location=self.parameters.couchbase_bak_loc,
                                                             csv_bucket_list=csv_bucket,
                                                             backup_repo=self.parameters.couchbase_bak_repo, 
                                                             skip=skip, 
-                                                            base_path=helper_lib.get_base_directory_of_given_path(self.repository.cb_shell_path)
+                                                            base_path=helper_lib.get_base_directory_of_given_path(self.repository.cb_shell_path),
+                                                            map_data=",".join(map_data_list),
+                                                            repo_version = self.repository.version
                                                         )
 
         if exit_code != 0:

--- a/src/controller/couchbase_lib/_cluster.py
+++ b/src/controller/couchbase_lib/_cluster.py
@@ -71,6 +71,12 @@ class _ClusterMixin(Resource, MixinInterface):
         env['additional_services'] = additional_service
         if int(self.repository.version.split(".")[0]) >= 7:
             env.update(kwargs[ENV_VAR_KEY])
+            if "(CE)" in self.repository.version:
+                env["cluster_eventing_ramsize"] = None
+                env["cluster_analytics_ramsize"] = None
+                env["indexerStorageMode"] = "forestdb"
+            else:
+                env["indexerStorageMode"] = "plasma"
             cmd, env_vars = CommandFactory.cluster_init_rest_expect(cluster_name=cluster_name, **env)
             kwargs[ENV_VAR_KEY].update(env_vars)
             stdout, stderr, exit_code = utilities.execute_expect(self.connection,

--- a/src/controller/couchbase_lib/_cluster.py
+++ b/src/controller/couchbase_lib/_cluster.py
@@ -69,7 +69,7 @@ class _ClusterMixin(Resource, MixinInterface):
         lambda_expr = lambda output: bool(re.search(ALREADY_CLUSTER_INIT, output))
         env = _ClusterMixin.generate_environment_map(self)
         env['additional_services'] = additional_service
-        if int(self.repository.version.split(".")[0]) == 7:
+        if int(self.repository.version.split(".")[0]) >= 7:
             env.update(kwargs[ENV_VAR_KEY])
             cmd, env_vars = CommandFactory.cluster_init_rest_expect(cluster_name=cluster_name, **env)
             kwargs[ENV_VAR_KEY].update(env_vars)

--- a/src/controller/couchbase_lib/_cluster.py
+++ b/src/controller/couchbase_lib/_cluster.py
@@ -69,10 +69,17 @@ class _ClusterMixin(Resource, MixinInterface):
         lambda_expr = lambda output: bool(re.search(ALREADY_CLUSTER_INIT, output))
         env = _ClusterMixin.generate_environment_map(self)
         env['additional_services'] = additional_service
-        cmd = CommandFactory.cluster_init(cluster_name=cluster_name, **env)
-        logger.debug("Cluster init: {}".format(cmd))
-        stdout, stderr, exit_code = utilities.execute_bash(self.connection, command_name=cmd, callback_func=lambda_expr,
-                                                           **kwargs)
+        if int(self.repository.version.split(".")[0]) == 7:
+            env.update(kwargs[ENV_VAR_KEY])
+            cmd, env_vars = CommandFactory.cluster_init_rest_expect(cluster_name=cluster_name, **env)
+            kwargs[ENV_VAR_KEY].update(env_vars)
+            stdout, stderr, exit_code = utilities.execute_expect(self.connection,
+                                                                 cmd, **kwargs)
+        else:
+            cmd = CommandFactory.cluster_init(cluster_name=cluster_name, **env)
+            logger.debug("Cluster init: {}".format(cmd))
+            stdout, stderr, exit_code = utilities.execute_bash(self.connection, command_name=cmd, callback_func=lambda_expr,
+                                                               **kwargs)
         if re.search(r"ERROR", str(stdout)):
             if re.search(r"ERROR: Cluster is already initialized", stdout):
                 logger.debug("Performing cluster setting as cluster is already initialized")

--- a/src/controller/couchbase_lib/_xdcr.py
+++ b/src/controller/couchbase_lib/_xdcr.py
@@ -7,6 +7,7 @@
 This class contains methods for XDCR related operations
 This is child class of Resource and parent class of CouchbaseOperation
 """
+import json
 #######################################################################################################################
 import logging
 from utils import utilities
@@ -260,7 +261,7 @@ class _XDCrMixin(Resource, MixinInterface):
         config_setting = self.staged_source.parameters.config_settings_prov
 
         if len(config_setting) > 0:
-            bucket_list = [ config_bucket["bucketName"] for config_bucket in config_setting ]
+            bucket_list = [config_bucket["bucketName"] for config_bucket in config_setting]
         else:
             bucket_details_source = self.source_bucket_list()
             bucket_list = helper_lib.filter_bucket_name_from_json(bucket_details_source)
@@ -272,6 +273,45 @@ class _XDCrMixin(Resource, MixinInterface):
 
         for bkt_name in bucket_list:
             if bkt_name not in alredy_replicated_buckets:
+                if int(self.repository.version.split(".")[0]) == 7:
+                    logger.debug(f"bucket_name: {bkt_name}")
+                    stdout, _, _ = self.run_couchbase_command(
+                        couchbase_command='get_scope_list_expect',
+                        base_path=helper_lib.get_base_directory_of_given_path(
+                            self.repository.cb_shell_path),
+                        hostname=self.source_config.couchbase_src_host,
+                        port=self.source_config.couchbase_src_port,
+                        username=self.staged_source.parameters.xdcr_admin,
+                        password=self.staged_source.parameters.xdcr_admin_password,
+                        bucket_name=bkt_name
+                    )
+                    json_scope_data = json.loads(stdout)
+                    logger.debug(f"json_scope_data={json_scope_data}")
+                    for s in json_scope_data["scopes"]:
+                        scope_name = s["name"]
+                        if scope_name == "_default":
+                            continue
+                        # create scope
+                        self.run_couchbase_command(
+                            couchbase_command="create_scope_expect",
+                            base_path=helper_lib.get_base_directory_of_given_path(self.repository.cb_shell_path),
+                            scope_name=scope_name,
+                            bucket_name=bkt_name
+                        )
+                        collection_list = s["collections"]
+                        for c in collection_list:
+                            collection_name = c["name"]
+                            if collection_name == "_default":
+                                continue
+                            # create collection
+                            self.run_couchbase_command(
+                                couchbase_command="create_collection_expect",
+                                base_path=helper_lib.get_base_directory_of_given_path(self.repository.cb_shell_path),
+                                scope_name=scope_name,
+                                bucket_name=bkt_name,
+                                collection_name=collection_name
+                            )
+
                 logger.debug("Creating replication for {}".format(bkt_name))
                 self.xdcr_replicate(bkt_name, bkt_name)
             else:

--- a/src/controller/couchbase_lib/_xdcr.py
+++ b/src/controller/couchbase_lib/_xdcr.py
@@ -273,7 +273,7 @@ class _XDCrMixin(Resource, MixinInterface):
 
         for bkt_name in bucket_list:
             if bkt_name not in alredy_replicated_buckets:
-                if int(self.repository.version.split(".")[0]) == 7:
+                if int(self.repository.version.split(".")[0]) >= 7:
                     logger.debug(f"bucket_name: {bkt_name}")
                     stdout, _, _ = self.run_couchbase_command(
                         couchbase_command='get_scope_list_expect',

--- a/src/controller/couchbase_operation.py
+++ b/src/controller/couchbase_operation.py
@@ -641,18 +641,6 @@ class CouchbaseOperation(_BucketMixin, _ClusterMixin, _XDCrMixin, _CBBackupMixin
 
         if self.parameters.d_source_type == constants.CBBKPMGR:
             logger.debug("Only build for backup ingestion")
-            # logger.debug(f"couchbase repository: {self.repository}")
-            #
-            # buckets = {}
-            # for i in indexes_raw['indexes']:
-            #     if i['bucket'] in buckets:
-            #         buckets[i['bucket']].append(i['indexName'])
-            #     else:
-            #         buckets[i['bucket']] = [ i['indexName'] ]
-            #
-            # for buc, ind in buckets.items():
-            #     ind_def = 'build index on `{}` (`{}`)'.format(buc, '`,`'.join(ind))
-            #     indexes.append(ind_def)
             buckets = {}
             for i in indexes_raw['indexes']:
                 bucket_name = i['bucket']
@@ -906,7 +894,7 @@ class CouchbaseOperation(_BucketMixin, _ClusterMixin, _XDCrMixin, _CBBackupMixin
                      f" , command_stderr=={command_stderr} , "
                      f"command_exit_code=={command_exit_code}")
         if command_output == "Found":
-            command_output, command_stderr, command_exit_code = self.run_os_command(
+            self.run_os_command(
                 os_command="delete_dir",
                 dirname=data_folder
             )

--- a/src/controller/couchbase_operation.py
+++ b/src/controller/couchbase_operation.py
@@ -912,7 +912,7 @@ class CouchbaseOperation(_BucketMixin, _ClusterMixin, _XDCrMixin, _CBBackupMixin
             )
 
     def delete_config_folder(self):
-        if int(self.repository.version.split(".")[0]) == 7:
+        if int(self.repository.version.split(".")[0]) >= 6:
             config_directory_path = "{}/../var/lib/couchbase/config".format(
                 helper_lib.get_base_directory_of_given_path(
                     self.repository.cb_shell_path))
@@ -942,6 +942,13 @@ class CouchbaseOperation(_BucketMixin, _ClusterMixin, _XDCrMixin, _CBBackupMixin
                 logger.debug(f"mv directory >> command_output=={command_output}"
                              f" , command_stderr=={command_stderr} , "
                              f"command_exit_code=={command_exit_code}")
+
+    def delete_xdcr_config(self):
+        if self.parameters.d_source_type == "XDCR":
+            is_xdcr_setup, cluster_name = self.delete_replication()
+            if is_xdcr_setup:
+                logger.info("Deleting XDCR")
+                self.xdcr_delete(cluster_name)
 
     def restore_config(self, what, nodeno=1):
 

--- a/src/controller/couchbase_operation.py
+++ b/src/controller/couchbase_operation.py
@@ -827,16 +827,16 @@ class CouchbaseOperation(_BucketMixin, _ClusterMixin, _XDCrMixin, _CBBackupMixin
 
         if int(self.repository.version.split(".")[0]) >= 7:
             chronicle_target_dir = os.path.join(targetdir, f"chronicle_{nodeno}")
-            command_output, std_err, exit_code = self.run_os_command(
+            chronicle_target_dir_command_output, _, chronicle_target_dir_exit_code = self.run_os_command(
                 os_command='check_directory',
                 dir_path=chronicle_target_dir
             )
-            if exit_code == 0 and "Found" in command_output:
-                command_output, std_err, exit_code = self.run_os_command(
+            if chronicle_target_dir_exit_code == 0 and "Found" in chronicle_target_dir_command_output:
+                self.run_os_command(
                     os_command='delete_dir',
                     dirname=chronicle_target_dir
                 )
-            command_output, std_err, exit_code = self.run_os_command(
+            self.run_os_command(
                 os_command="os_cpr",
                 srcname="{}/../var/lib/couchbase/config/chronicle".format(helper_lib.get_base_directory_of_given_path(self.repository.cb_shell_path)),
                 trgname=chronicle_target_dir
@@ -918,11 +918,11 @@ class CouchbaseOperation(_BucketMixin, _ClusterMixin, _XDCrMixin, _CBBackupMixin
                     dir_path=target_folder
                 )
                 if command_output == "Found":
-                    command_output, command_stderr, command_exit_code = self.run_os_command(
+                    self.run_os_command(
                         os_command="delete_dir",
                         dirname=target_folder
                     )
-                command_output, command_stderr, command_exit_code = self.run_os_command(
+                self.run_os_command(
                     os_command='os_mv',
                     srcname=config_directory_path,
                     trgname=target_folder
@@ -1044,7 +1044,7 @@ class CouchbaseOperation(_BucketMixin, _ClusterMixin, _XDCrMixin, _CBBackupMixin
                 dir_path=target_chronicle_dirname
             )
             if exit_code == 0 and "Found" in command_output:
-                command_output, std_err, exit_code = self.run_os_command(
+                self.run_os_command(
                     os_command='delete_dir',
                     dirname=target_chronicle_dirname
                 )
@@ -1117,7 +1117,7 @@ class CouchbaseOperation(_BucketMixin, _ClusterMixin, _XDCrMixin, _CBBackupMixin
         logger.debug("fix local.ini permission - exit_code: {} stdout: {} std_err: {}".format(exit_code, command_output, std_err))
 
         chronicle_dir_name = "{}/../var/lib/couchbase/config/chronicle".format(helper_lib.get_base_directory_of_given_path(self.repository.cb_shell_path))
-        command_output, std_err, exit_code = self.run_os_command(
+        self.run_os_command(
             os_command='delete_dir',
             dirname=chronicle_dir_name
         )
@@ -1139,7 +1139,7 @@ class CouchbaseOperation(_BucketMixin, _ClusterMixin, _XDCrMixin, _CBBackupMixin
         #                                         newpass=self.parameters.couchbase_admin_password,
         #                                         newname=self.parameters.tgt_cluster_name
         #                                     )
-        command_output, std_err, exit_code = self.run_couchbase_command(
+        self.run_couchbase_command(
             couchbase_command='rename_cluster',
             username=self.snapshot.couchbase_admin,
             password=self.snapshot.couchbase_admin_password,

--- a/src/controller/couchbase_operation.py
+++ b/src/controller/couchbase_operation.py
@@ -754,7 +754,7 @@ class CouchbaseOperation(_BucketMixin, _ClusterMixin, _XDCrMixin, _CBBackupMixin
         target_local_filename = os.path.join(targetdir,"local.ini_{}".format(nodeno))
         target_encryption_filename = os.path.join(targetdir,"encrypted_data_keys_{}".format(nodeno))
 
-        if nodeno == 1 or int(self.repository.version.split(".")[0]) == 7:
+        if nodeno == 1 or int(self.repository.version.split(".")[0]) >= 7:
             ip_file = "{}/../var/lib/couchbase/ip".format(helper_lib.get_base_directory_of_given_path(self.repository.cb_shell_path))
             target_ip_filename = os.path.join(targetdir,"ip_{}".format(nodeno))
             output, err, exit_code = self.run_os_command(
@@ -837,7 +837,7 @@ class CouchbaseOperation(_BucketMixin, _ClusterMixin, _XDCrMixin, _CBBackupMixin
         if exit_code != 0:
             raise UserError("Error saving configuration file: local.ini", "Check sudo or user privileges to read Couchbase local.ini file", std_err)
 
-        if int(self.repository.version.split(".")[0]) == 7:
+        if int(self.repository.version.split(".")[0]) >= 7:
             chronicle_target_dir = os.path.join(targetdir, f"chronicle_{nodeno}")
             command_output, std_err, exit_code = self.run_os_command(
                 os_command='check_directory',
@@ -1048,7 +1048,7 @@ class CouchbaseOperation(_BucketMixin, _ClusterMixin, _XDCrMixin, _CBBackupMixin
 
         logger.debug("local.ini restore - exit_code: {} stdout: {} std_err: {}".format(exit_code, command_output, std_err))
 
-        if int(self.repository.version.split(".")[0]) == 7:
+        if int(self.repository.version.split(".")[0]) >= 7:
             source_chronicle_dirname = os.path.join(sourcedir, "chronicle_{}".format(nodeno))
             target_chronicle_dirname = "{}/../var/lib/couchbase/config/chronicle".format(helper_lib.get_base_directory_of_given_path(self.repository.cb_shell_path))
             command_output, std_err, exit_code = self.run_os_command(

--- a/src/controller/couchbase_operation.py
+++ b/src/controller/couchbase_operation.py
@@ -1210,10 +1210,11 @@ class CouchbaseOperation(_BucketMixin, _ClusterMixin, _XDCrMixin, _CBBackupMixin
         resolve_name_output, std_err, exit_code = utilities.execute_bash(self.connection, resolve_name_command)
         logger.debug("resolve_name_command Output {} ".format(resolve_name_output))
 
-        if "(CE)" in self.repository.version:
-            new_port = "8091"
-        else:
-            new_port = "18091"
+        if int(self.repository.version.split(".")[0]) >= 7:
+            if "(CE)" in self.repository.version:
+                new_port = "8091"
+            else:
+                new_port = "18091"
 
         command_output, std_err, exit_code = self.run_couchbase_command(
                                                 couchbase_command='server_add',

--- a/src/controller/couchbase_operation.py
+++ b/src/controller/couchbase_operation.py
@@ -1210,11 +1210,17 @@ class CouchbaseOperation(_BucketMixin, _ClusterMixin, _XDCrMixin, _CBBackupMixin
         resolve_name_output, std_err, exit_code = utilities.execute_bash(self.connection, resolve_name_command)
         logger.debug("resolve_name_command Output {} ".format(resolve_name_output))
 
+        if "(CE)" in self.repository.version:
+            new_port = "8091"
+        else:
+            new_port = "18091"
+
         command_output, std_err, exit_code = self.run_couchbase_command(
                                                 couchbase_command='server_add',
                                                 hostname=self.connection.environment.host.name,
                                                 newhost=resolve_name_output,
-                                                services=','.join(services)
+                                                services=','.join(services),
+                                                new_port=new_port
                                              )
 
 

--- a/src/controller/couchbase_operation.py
+++ b/src/controller/couchbase_operation.py
@@ -92,6 +92,11 @@ class CouchbaseOperation(_BucketMixin, _ClusterMixin, _XDCrMixin, _CBBackupMixin
         else:
             hostname = self.connection.environment.host.name
 
+        if "port" in kwargs:
+            port = kwargs.pop("port")
+        else:
+            port = self.parameters.couchbase_port
+
         env = {"password": password}
 
         if "newpass" in kwargs:
@@ -119,12 +124,14 @@ class CouchbaseOperation(_BucketMixin, _ClusterMixin, _XDCrMixin, _CBBackupMixin
                                      "server_add",
                                      "rebalance",
                                      "get_scope_list_expect",
-                                     "change_cluster_password"]:
+                                     "change_cluster_password",
+                                     "create_scope_expect",
+                                     "create_collection_expect"]:
             method_to_call = getattr(CommandFactory, couchbase_command)
             command = method_to_call(shell_path=self.repository.cb_shell_path,
                                  install_path=self.repository.cb_install_path,
                                  username=username,
-                                 port=self.parameters.couchbase_port,
+                                 port=port,
                                  sudo=self.need_sudo,
                                  uid=self.uid,
                                  hostname=hostname,
@@ -139,7 +146,7 @@ class CouchbaseOperation(_BucketMixin, _ClusterMixin, _XDCrMixin, _CBBackupMixin
             command, env_vars = method_to_call(shell_path=self.repository.cb_shell_path,
                                                install_path=self.repository.cb_install_path,
                                                username=username,
-                                               port=self.parameters.couchbase_port,
+                                               port=port,
                                                sudo=self.need_sudo,
                                                uid=self.uid,
                                                hostname=hostname,

--- a/src/controller/couchbase_operation.py
+++ b/src/controller/couchbase_operation.py
@@ -1215,6 +1215,8 @@ class CouchbaseOperation(_BucketMixin, _ClusterMixin, _XDCrMixin, _CBBackupMixin
                 new_port = "8091"
             else:
                 new_port = "18091"
+        else:
+            new_port = "18091"
 
         command_output, std_err, exit_code = self.run_couchbase_command(
                                                 couchbase_command='server_add',

--- a/src/db_commands/commands.py
+++ b/src/db_commands/commands.py
@@ -114,7 +114,7 @@ class OSCommand(object):
         if sudo:
             return "sudo -u \#{uid} cp -r {srcname} {trgname}".format(srcname=srcname, trgname=trgname, uid=uid)
         else:
-            return "cp -r {srcname} {trgname}".format(srcname=srcname, trgname=trgname, uid=uid)
+            return "cp -r {srcname} {trgname}".format(srcname=srcname, trgname=trgname)
 
     @staticmethod
     def get_dlpx_bin(**kwargs):

--- a/src/db_commands/commands.py
+++ b/src/db_commands/commands.py
@@ -281,7 +281,7 @@ class DatabaseCommand(object):
         }
         payload_data["services"] = payload_data["services"].replace("data", "kv").replace("query", "n1ql")
         payload_string = urllib.parse.urlencode(payload_data)
-        command = f'echo \"{payload_string}\" | curl -d @- -X POST http://127.0.0.1:{port}/clusterInit -u {username}'
+        command = f'echo \"$PAYLOAD_SECRET\" | curl -d @- -X POST http://127.0.0.1:{port}/clusterInit -u {username}'
         expect_block = DatabaseCommand.get_parent_expect_block().format(
             command_specific_operations="""eval spawn ${env(CB_CMD)}
                                     expect {
@@ -300,7 +300,8 @@ class DatabaseCommand(object):
         env_vars = {
             "CB_PWD": kwargs.get("password"),
             "CB_CMD": "/tmp/run_shell.sh",
-            "SHELL_DATA": command
+            "SHELL_DATA": command,
+            "PAYLOAD_SECRET": payload_string
         }
         return expect_block, env_vars
 
@@ -342,6 +343,7 @@ class DatabaseCommand(object):
                                                 }
                                             }"""
         )
+        logger.debug(f"command: {command}")
         env_vars = {
             "CB_PWD": kwargs.get("password"),
             "CB_CMD": command
@@ -372,7 +374,7 @@ class DatabaseCommand(object):
             "demandEncryption": 0
         }
         payload_string = urllib.parse.urlencode(payload_data)
-        command = f"echo \"{payload_string}\" | curl -d @- -X POST http://{source_hostname}:{source_port}/pools/default/remoteClusters -u {source_username}"
+        command = f"echo \"$PAYLOAD_SECRET\" | curl -d @- -X POST http://{source_hostname}:{source_port}/pools/default/remoteClusters -u {source_username}"
         expect_block = DatabaseCommand.get_parent_expect_block().format(
             command_specific_operations="""eval spawn ${env(CB_CMD)}
                                                     expect {
@@ -391,7 +393,8 @@ class DatabaseCommand(object):
         env_vars = {
             "CB_PWD": kwargs.get("source_password"),
             "CB_CMD": "/tmp/run_shell.sh",
-            "SHELL_DATA": command
+            "SHELL_DATA": command,
+            "PAYLOAD_SECRET": payload_string
         }
         return expect_block, env_vars
 
@@ -426,6 +429,7 @@ class DatabaseCommand(object):
                                                 }
                                             }"""
         )
+        logger.debug(f"command: {command}")
         env_vars = {
             "CB_PWD": kwargs.get("source_password"),
             "CB_CMD": command
@@ -462,6 +466,7 @@ class DatabaseCommand(object):
                                         }
                                     }"""
         )
+        logger.debug(f"command: {command}")
         env_vars = {
             "CB_PWD": kwargs.get("source_password"),
             "CB_CMD": command
@@ -495,6 +500,7 @@ class DatabaseCommand(object):
                                         }
                                     }"""
         )
+        logger.debug(f"command: {command}")
         env_vars = {
             "CB_PWD": kwargs.get("source_password"),
             "CB_CMD": command
@@ -529,6 +535,7 @@ class DatabaseCommand(object):
                                                         }
                                                     }"""
         )
+        logger.debug(f"command: {command}")
         env_vars = {
             "CB_PWD": kwargs.get("source_password"),
             "CB_CMD": command
@@ -563,6 +570,7 @@ class DatabaseCommand(object):
                                                             }
                                                         }"""
         )
+        logger.debug(f"command: {command}")
         env_vars = {
             "CB_PWD": kwargs.get("source_password"),
             "CB_CMD": command
@@ -597,6 +605,7 @@ class DatabaseCommand(object):
                                                                     }
                                                                 }"""
         )
+        logger.debug(f"command: {command}")
         env_vars = {
             "CB_PWD": kwargs.get("source_password"),
             "CB_CMD": command
@@ -666,6 +675,7 @@ class DatabaseCommand(object):
                                 }
                             }"""
         )
+        logger.debug(f"command: {command}")
         env_vars = {
             "CB_PWD": kwargs.get("password"),
             "CB_CMD": command
@@ -694,6 +704,7 @@ class DatabaseCommand(object):
                 }
             }"""
         )
+        logger.debug(f"command: {command}")
         env_vars = {
             "CB_PWD": kwargs.get("password"),
             "CB_CMD": command
@@ -722,6 +733,7 @@ class DatabaseCommand(object):
                         }
                     }"""
         )
+        logger.debug(f"command: {command}")
         env_vars = {
             "CB_PWD": kwargs.get("password"),
             "CB_CMD": command
@@ -752,6 +764,7 @@ class DatabaseCommand(object):
                                 }
                             }"""
         )
+        logger.debug(f"command: {command}")
         env_vars = {
             "CB_PWD": kwargs.get("password"),
             "CB_CMD": command
@@ -782,6 +795,7 @@ class DatabaseCommand(object):
                                         }
                                     }"""
         )
+        logger.debug(f"command: {command}")
         env_vars = {
             "CB_PWD": kwargs.get("password"),
             "CB_CMD": command
@@ -811,6 +825,7 @@ class DatabaseCommand(object):
                                         }
                                     }"""
         )
+        logger.debug(f"command: {command}")
         env_vars = {
             "CB_PWD": kwargs.get("password"),
             "CB_CMD": command
@@ -845,6 +860,7 @@ class DatabaseCommand(object):
                                         }
                                     }"""
         )
+        logger.debug(f"command: {command}")
         env_vars = {
             "CB_PWD": kwargs.get("password"),
             "CB_CMD": command
@@ -877,6 +893,7 @@ class DatabaseCommand(object):
                                                 }
                                             }"""
         )
+        logger.debug(f"command: {command}")
         env_vars = {
             "CB_PWD": kwargs.get("password"),
             "CB_CMD": command
@@ -905,6 +922,7 @@ class DatabaseCommand(object):
                         }
                     }"""
         )
+        logger.debug(f"command: {command}")
         env_vars = {
             "CB_PWD": kwargs.get("password"),
             "CB_CMD": command
@@ -933,6 +951,7 @@ class DatabaseCommand(object):
                                 }
                             }"""
         )
+        logger.debug(f"command: {command}")
         env_vars = {
             "CB_PWD": kwargs.get("password"),
             "CB_CMD": command
@@ -955,6 +974,7 @@ class DatabaseCommand(object):
                                         }
                                     }"""
         )
+        logger.debug(f"command: {command}")
         env_vars = {
             "CB_PWD": kwargs.get("password"),
             "CB_CMD": command
@@ -988,6 +1008,8 @@ class DatabaseCommand(object):
                                                 }
                                             }"""
         )
+        logger.debug(f"command: {command}")
+        logger.debug(f"cb_query: {cb_query}")
         env_vars = {
             "CB_PWD": kwargs.get("password"),
             "CB_CMD": command,
@@ -1022,6 +1044,8 @@ class DatabaseCommand(object):
                                                 }
                                             }"""
         )
+        logger.debug(f"command: {command}")
+        logger.debug(f"cb_query: {cb_query}")
         env_vars = {
             "CB_PWD": kwargs.get("password"),
             "CB_CMD": command,
@@ -1072,6 +1096,8 @@ class DatabaseCommand(object):
                                         }
                                     }"""
         )
+        logger.debug(f"command: {command}")
+        logger.debug(f"cb_query: {index_def}")
         env_vars = {
             "CB_PWD": kwargs.get("password"),
             "CB_CMD": command,
@@ -1088,6 +1114,7 @@ class DatabaseCommand(object):
     @staticmethod
     def check_index_build_expect(base_path, hostname, port, username, **kwargs):
         command = f"{base_path}/cbq -e {hostname}:{port} -u {username} -q=true"
+        cb_query = "SELECT COUNT(*) as unbuilt FROM system:indexes WHERE state <> 'online'"
         expect_block = DatabaseCommand.get_parent_expect_block().format(
             command_specific_operations="""eval spawn ${env(CB_CMD)}
                                             expect {
@@ -1111,10 +1138,12 @@ class DatabaseCommand(object):
                                                 }
                                             }"""
         )
+        logger.debug(f"command: {command}")
+        logger.debug(f"cb_query: {cb_query}")
         env_vars = {
             "CB_PWD": kwargs.get("password"),
             "CB_CMD": command,
-            "CB_QUERY": "SELECT COUNT(*) as unbuilt FROM system:indexes WHERE state <> 'online'"
+            "CB_QUERY": cb_query
         }
         return expect_block, env_vars
 
@@ -1155,7 +1184,7 @@ class DatabaseCommand(object):
         else:
             command = f"{base_path}/cbbackupmgr restore --archive {backup_location} --repo {backup_repo} --cluster couchbase://{hostname}:{port} --username {username} --password \
                         --force-updates {skip} --no-progress-bar --include-buckets {csv_bucket_list}"
-        if int(kwargs.get("repo_version").split(".")[0]) == 7:
+        if int(kwargs.get("repo_version").split(".")[0]) >= 7:
             command = f"{command} --purge"
         if kwargs.get("map_data") != "":
             command = f"{command} --map-data {kwargs.get('map_data')}"
@@ -1178,7 +1207,7 @@ class DatabaseCommand(object):
                                 }
                             }"""
         )
-        logger.debug(f"restore command:::: {command}")
+        logger.debug(f"command: {command}")
         env_vars = {
             "CB_PWD": kwargs.get("password"),
             "CB_CMD": command
@@ -1212,6 +1241,7 @@ class DatabaseCommand(object):
                                         }
                                     }"""
         )
+        logger.debug(f"command: {command}")
         env_vars = {
             "CB_PWD": kwargs.get("password"),
             "CB_CMD": command
@@ -1241,6 +1271,7 @@ class DatabaseCommand(object):
                         }
                     }"""
         )
+        logger.debug(f"command: {command}")
         env_vars = {
             "CB_PWD": kwargs.get("password"),
             "CB_CMD": command
@@ -1270,6 +1301,7 @@ class DatabaseCommand(object):
                                         }
                                     }"""
         )
+        logger.debug(f"command: {command}")
         env_vars = {
             "CB_PWD": kwargs.get("password"),
             "CB_CMD": command
@@ -1279,7 +1311,7 @@ class DatabaseCommand(object):
     @staticmethod
     def change_cluster_password_expect(shell_path, hostname, port, username, newuser, **kwargs):
         payload_string = f"password={kwargs.get('newpass')}&username={newuser}&port=SAME"
-        command = f'echo \"{payload_string}\" | curl -d @- -X POST http://{hostname}:{port}/settings/web -u {username}'
+        command = f'echo \"$PAYLOAD_SECRET\" | curl -d @- -X POST http://{hostname}:{port}/settings/web -u {username}'
         expect_block = DatabaseCommand.get_parent_expect_block().format(
             command_specific_operations="""eval spawn ${env(CB_CMD)}
                                             expect {
@@ -1298,7 +1330,8 @@ class DatabaseCommand(object):
         env_vars = {
             "CB_PWD": kwargs.get("password"),
             "CB_CMD": "/tmp/run_shell.sh",
-            "SHELL_DATA": command
+            "SHELL_DATA": command,
+            "PAYLOAD_SECRET": payload_string
         }
         return expect_block, env_vars
 
@@ -1321,7 +1354,7 @@ class DatabaseCommand(object):
         }
         payload_data["services"] = payload_data["services"].replace("data", "kv").replace("query", "n1ql")
         payload_string = urllib.parse.urlencode(payload_data)
-        command = f"echo \"{payload_string}\" | curl -d @- -X POST {hostname}:8091/controller/addNode -u {username}"
+        command = f"echo \"$PAYLOAD_SECRET\" | curl -d @- -X POST {hostname}:8091/controller/addNode -u {username}"
         expect_block = DatabaseCommand.get_parent_expect_block().format(
             command_specific_operations="""eval spawn ${env(CB_CMD)}
                                             expect {
@@ -1340,7 +1373,8 @@ class DatabaseCommand(object):
         env_vars = {
             "CB_PWD": kwargs.get("password"),
             "CB_CMD": "/tmp/run_shell.sh",
-            "SHELL_DATA": command
+            "SHELL_DATA": command,
+            "PAYLOAD_SECRET": payload_string
         }
         return expect_block, env_vars
 
@@ -1370,7 +1404,7 @@ class DatabaseCommand(object):
                                         }
                                     }"""
         )
-        logger.debug(f"rebalance command ::::: {command}")
+        logger.debug(f"command: {command}")
         env_vars = {
             "CB_PWD": kwargs.get("password"),
             "CB_CMD": command

--- a/src/db_commands/commands.py
+++ b/src/db_commands/commands.py
@@ -14,8 +14,6 @@ so no need to create an object of the class, we can use the direct class name to
 #######################################################################################################################
 
 
-import inspect
-import json
 import logging
 import urllib.parse
 

--- a/src/db_commands/commands.py
+++ b/src/db_commands/commands.py
@@ -637,7 +637,7 @@ class DatabaseCommand(object):
         logger.debug(f"command: {command}")
         env_vars = {
             "CB_PWD": kwargs.get("source_password"),
-            "CB_CMD": "command"
+            "CB_CMD": command
         }
         return expect_block, env_vars
 

--- a/src/operations/link_xdcr.py
+++ b/src/operations/link_xdcr.py
@@ -27,6 +27,8 @@ logger = logging.getLogger(__name__)
 
 def resync_xdcr(staged_source, repository, source_config, input_parameters):
     logger.debug("START resync_xdcr")
+    if input_parameters.xdcr_admin_password == "":
+        raise UserError("Source password is mandatory in XDCR dsource type!")
     dsource_type = input_parameters.d_source_type
     dsource_name = source_config.pretty_name
     bucket_size = staged_source.parameters.bucket_size

--- a/src/operations/linking.py
+++ b/src/operations/linking.py
@@ -74,9 +74,11 @@ def configure_cluster(couchbase_obj):
         logger.debug("cluster config not found - preparing node")
         # no config in delphix directory
         # initial cluster setup
+        couchbase_obj.delete_xdcr_config()
         couchbase_obj.stop_couchbase()
         couchbase_obj.delete_data_folder()
         couchbase_obj.delete_config_folder()
+
         # we can't use normal monitor as server is not configured yet 
         couchbase_obj.start_couchbase(no_wait=True)
 

--- a/src/operations/linking.py
+++ b/src/operations/linking.py
@@ -75,6 +75,8 @@ def configure_cluster(couchbase_obj):
         # no config in delphix directory
         # initial cluster setup
         couchbase_obj.stop_couchbase()
+        couchbase_obj.delete_data_folder()
+        couchbase_obj.delete_config_folder()
         # we can't use normal monitor as server is not configured yet 
         couchbase_obj.start_couchbase(no_wait=True)
 

--- a/src/operations/virtual.py
+++ b/src/operations/virtual.py
@@ -60,7 +60,6 @@ def vdb_unconfigure(virtual_source, repository, source_config):
     vdb_stop(virtual_source, repository, source_config)
     provision_process.delete_config()
 
-
     if provision_process.parameters.node_list is not None and len(provision_process.parameters.node_list) > 0:
         for node in provision_process.parameters.node_list:
             logger.debug("+++++++++++++++++++++++++++")
@@ -176,6 +175,7 @@ def vdb_configure(virtual_source, snapshot, repository):
 
     # to make sure there is no config 
     provision_process.delete_config()
+    # provision_process.delete_config_folder()
 
 
     provision_process.restore_config(what='parent')
@@ -201,6 +201,8 @@ def vdb_configure(virtual_source, snapshot, repository):
 
     provision_process.restart_couchbase(provision=True)
     provision_process.rename_cluster()
+    # provision_process.node_init()
+    # provision_process.cluster_init()
     #provision_process.node_init()
     #provision_process.cluster_init()
     

--- a/src/utils/utilities.py
+++ b/src/utils/utilities.py
@@ -54,8 +54,8 @@ def execute_expect(source_connection, command_name, callback_func=None, environm
 
     file_random_id = random.randint(1000000000, 9999999999)
 
-    logger.debug(f"environment_vars: {environment_vars}")
     if "SHELL_DATA" in environment_vars:
+        environment_vars["CB_CMD"] = environment_vars["CB_CMD"].replace(".sh", f"_{file_random_id}.sh")
         result = libs.run_bash(
             source_connection,
             command=f'echo -e "$SHELL_DATA" > $CB_CMD',
@@ -119,6 +119,12 @@ def execute_expect(source_connection, command_name, callback_func=None, environm
         command=f"rm -rf {file_path}",
         use_login_shell=True
     )
+    if "SHELL_DATA" in environment_vars:
+        libs.run_bash(
+            source_connection,
+            command=f"rm -rf $CB_CMD",
+            use_login_shell=True
+        )
 
     if "DLPX_EXPECT_EXIT_CODE" in output:
         exit_code = int(output.split("DLPX_EXPECT_EXIT_CODE:")[1].split("\n")[0])

--- a/src/utils/utilities.py
+++ b/src/utils/utilities.py
@@ -7,9 +7,6 @@ import logging
 from dlpx.virtualization import libs
 from dlpx.virtualization.libs import exceptions
 import random
-from db_commands.constants import ENV_VAR_KEY
-
-from db_commands import commands
 
 # logger object
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
Problem:
* Couchbase version 7.1.3 support
* REST API implementation for cluster-init
* REST API implementation for xdcr-setup
* REST API implementation for setting-cluster

Tickets Addressed:
* CE-509 REST API implementation for cluster-init
* CE-510 REST API implementation for xdcr-setup
* CE-511 REST API implementation for setting-cluster
* CE-518 index creation inside scope support
* CE-519 snapshot fails with backup restore failure
* CE-520 status check of replication fails in xdcr dsource type
* CE-521 cluster init fails when couchbase instance is recreated on a machine
* CE-523 bucket-flush command fix
* CE-525 server-add command fix
* CE-542 VDB creation fix for couchbase version 7.1.3
* CE-543 scope and collection pre-creation for xdcr dsource type
* CE-544 fix XDCR delete configuration
* CE-545 code hardening
* CE-546 plugin version upgrade
* CE-547 CodeQL fixes
* CE-550 Changes in cluster-init and server-add for couchbase 7.1.1